### PR TITLE
Release 0.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,40 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Check module version
-        uses: tarantool/actions/check-module-version@master
+      # We can not use 'tarantool/check-module-version' action since it installs Tarantool 2.10.
+      # For this module we need Tarantool 3.
+      - name: Clone the module
+        uses: actions/checkout@v3
+
+      - name: Install tarantool 3.1
+        uses: tarantool/setup-tarantool@v3
         with:
-          module-name: 'metrics-export-role'
+          tarantool-version: '3.1'
+
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/XodVosJ/release/3/installer.sh | bash
+          sudo apt install -y tt
+          tt version
+
+      # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
+      - name: Set env
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - run: tt rocks make
+
+      - name: Check package version
+        run: |
+          REPO_TAG=${GIT_TAG}
+          MODULE_VERSION=$(tarantool -e "print(require('roles.metrics-export')._VERSION)")
+          echo "Detected version from code is $MODULE_VERSION"
+          echo "Detected repo tag is $REPO_TAG"
+          if [ "$MODULE_VERSION" != "$REPO_TAG" ]; then
+            echo "::error::Version from code and the last repository tag are not equal"
+            echo "::notice::You may have forgotten to update the value in the version.lua file"
+            exit 1
+          fi
+        shell: bash
 
   publish-rockspec-scm-1:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The role implementation (#6).
-- A documentation for the role to README.md (#5).
-
 ### Fixed
 
 ### Changed
 
+## 0.1.0 - 2024-06-11
+
+The release introduces the `metrics-export-role` module: export metrics
+from `Tarantool` 3. The release contains role for `Tarantool` 3 with
+documentation.
+
+### Added
+
+- The role implementation (#6).
+- A documentation for the role to README.md (#5).

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -3,6 +3,10 @@ local http_server = require('http.server')
 
 local M = {}
 
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+M._VERSION = "0.1.0"
+
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")
     for k, _ in pairs(tbl) do


### PR DESCRIPTION
## Overview

The release introduces the `metrics-export-role` module: export metrics from `Tarantool` 3.
The release contains role for `Tarantool` 3.

## New features

* `Tarantool` 3 role with documentation.