### PR TITLE
api: introduce latency observation for http endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Introduce latency observation for http endpoint (#17).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ incoming requests. An individual endpoint can be described as:
   format: format_to_export
 ```
 
+Optionally, you can enable
+[http metrics](https://www.tarantool.io/en/doc/latest/reference/reference_lua/metrics/#collecting-http-metrics)
+for each endpoint. For this you should
+set `metrics.enabled` to `true`:
+
+```yaml
+- path: /path/to/export/on/the/server
+  format: format_to_export
+  metrics:
+    enabled: true
+```
+
 For now only `json` and `prometheus` formats are supported.
 
 Let's put it all together now:
@@ -107,6 +119,8 @@ roles_cfg:
       endpoints:
       - path: /metrics/
         format: json
+        metrics:
+          enabled: true
 ```
 
 With this configuration, metrics can be obtained on this machine with the

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -25,6 +25,10 @@ groups:
                     format: prometheus
                   - path: /metrics/json/
                     format: json
+                  - path: /metrics/observed/prometheus
+                    format: prometheus
+                    metrics:
+                      enabled: true
             iproto:
               listen:
                 - uri: '127.0.0.1:3313'

--- a/test/unit/middleware_test.lua
+++ b/test/unit/middleware_test.lua
@@ -1,0 +1,138 @@
+local http_client = require('http.client')
+local http_middleware = require('metrics.http_middleware')
+local metrics = require('metrics')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.role = require('roles.metrics-export')
+end)
+
+g.before_each(function(cg)
+    cg.collector_name = http_middleware.get_default_collector().name
+end)
+
+g.after_each(function(cg)
+    metrics.clear()
+    http_middleware.set_default_collector(nil)
+
+    cg.role.stop()
+end)
+
+local function assert_contains_http(cg, uri, path_pattern)
+    local response = http_client.get(uri)
+    t.assert(response.body)
+
+    local data = response.body
+    local expected = ("%s_count"):format(cg.collector_name)
+    if path_pattern ~= nil then
+        expected = expected .. ".*" .. path_pattern
+    end
+    t.assert_str_contains(data, expected, true)
+end
+
+local function assert_not_contains_http(cg, uri, path_pattern)
+    local response = http_client.get(uri)
+    t.assert(response.body)
+
+    local data = response.body
+    local expected = ("%s_count"):format(cg.collector_name)
+    if path_pattern ~= nil then
+        expected = expected .. ".*" .. path_pattern
+    end
+    t.assert_not_str_contains(data, expected, true)
+end
+
+local function trigger_http(uri)
+    local response = http_client.get(uri)
+    t.assert(response.body)
+end
+
+g.test_http_metrics_disabled_by_default = function(cg)
+    cg.role.apply({
+        http = {
+            {
+                listen = 8081,
+                endpoints = {
+                    {
+                        path = "/prometheus",
+                        format = "prometheus",
+                    },
+                    {
+                        path = "/json",
+                        format = "json",
+                    },
+                },
+            },
+        },
+    })
+
+    trigger_http("http://127.0.0.1:8081/prometheus")
+    trigger_http("http://127.0.0.1:8081/json")
+
+
+    assert_not_contains_http(cg, "http://127.0.0.1:8081/prometheus")
+    assert_not_contains_http(cg, "http://127.0.0.1:8081/json")
+end
+
+g.test_enabled_http_metrics = function(cg)
+    cg.role.apply({
+        http = {
+            {
+                listen = 8081,
+                endpoints = {
+                    {
+                        path = "/prometheus",
+                        format = "prometheus",
+                        metrics = {enabled = true},
+                    },
+                    {
+                        path = "/json",
+                        format = "json",
+                        metrics = {enabled = true},
+                    },
+                },
+            },
+        },
+    })
+
+    trigger_http("http://127.0.0.1:8081/prometheus")
+    trigger_http("http://127.0.0.1:8081/json")
+
+    assert_contains_http(cg, "http://127.0.0.1:8081/prometheus", [[path="/prometheus"]])
+    assert_contains_http(cg, "http://127.0.0.1:8081/prometheus", [[path="/json"]])
+
+    assert_contains_http(cg, "http://127.0.0.1:8081/json", [["path":"/prometheus"]])
+    assert_contains_http(cg, "http://127.0.0.1:8081/json", [["path":"/json"]])
+end
+
+g.test_enabled_http_metrics_for_one_endpoint = function(cg)
+    cg.role.apply({
+        http = {
+            {
+                listen = 8081,
+                endpoints = {
+                    {
+                        path = "/prometheus",
+                        format = "prometheus",
+                        metrics = {enabled = true},
+                    },
+                    {
+                        path = "/json",
+                        format = "json",
+                    },
+                },
+            },
+        },
+    })
+
+    trigger_http("http://127.0.0.1:8081/prometheus")
+    trigger_http("http://127.0.0.1:8081/json")
+
+    assert_contains_http(cg, "http://127.0.0.1:8081/prometheus", [[path="/prometheus"]])
+    assert_contains_http(cg, "http://127.0.0.1:8081/json", [["path":"/prometheus"]])
+
+    assert_not_contains_http(cg, "http://127.0.0.1:8081/prometheus", [[path="/json"]])
+    assert_not_contains_http(cg, "http://127.0.0.1:8081/json", [["path":"/json"]])
+end

--- a/test/unit/validate_test.lua
+++ b/test/unit/validate_test.lua
@@ -379,6 +379,59 @@ local error_cases = {
         },
         err = "http configuration nodes must have different listen targets",
     },
+    ["http_endpoint_metrics_is_not_table "] = {
+        cfg = {
+            http = {
+                {
+                    listen = "localhost:123",
+                    endpoints = {
+                        {
+                            path = "/",
+                            format = "json",
+                            metrics = "",
+                        },
+                    },
+                },
+            },
+        },
+        err = "http endpoint 'metrics' must be a table, got string",
+    },
+    ["http_endpoint_metrics_is_array"] = {
+        cfg = {
+            http = {
+                {
+                    listen = "localhost:123",
+                    endpoints = {
+                        {
+                            path = "/",
+                            format = "json",
+                            metrics = {1},
+                        },
+                    },
+                },
+            },
+        },
+        err = "http endpoint 'metrics' must be a map, not an array",
+    },
+    ["http_endpoint_metrics_enabled_is_not_bool"] = {
+        cfg = {
+            http = {
+                {
+                    listen = "localhost:123",
+                    endpoints = {
+                        {
+                            path = "/",
+                            format = "json",
+                            metrics = {
+                                enabled = 'true',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        err = "http endpoint metrics 'enabled' must be a boolean, got string",
+    },
 }
 
 for name, case in pairs(error_cases) do
@@ -541,6 +594,24 @@ local ok_cases = {
                 {
                     listen = "localhost:124",
                     endpoints = {},
+                },
+            },
+        },
+    },
+    ["http_endpoint_metrics_enabled_true"] = {
+        cfg = {
+            http = {
+                {
+                    listen = "localhost:123",
+                    endpoints = {
+                        {
+                            path = "/",
+                            format = "json",
+                            metrics = {
+                                enabled = true,
+                            },
+                        },
+                    },
                 },
             },
         },


### PR DESCRIPTION
This patch enables monitoring of HTTP endpoint latency.
The `metrics` object is added to the endpoint configuration to facilitate this.
When `metrics.enabled` is set to `true`, the endpoint handler is wrapped
with `metrics.http_middleware` to capture latency data.