### PR TITLE
api: migrate to httpd role server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Introduce latency observation for http endpoint (#17).
+- Support `roles.httpd` integration (#15).
 
 ### Fixed
 

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -9,8 +9,13 @@ groups:
       replicaset-001:
         instances:
           master:
-            roles: [roles.metrics-export]
+            roles: [roles.httpd, roles.metrics-export]
             roles_cfg:
+              roles.httpd:
+                default:
+                  listen: 8085
+                additional:
+                  listen: '127.0.0.1:8086'
               roles.metrics-export:
                 http:
                 - listen: 8081
@@ -26,6 +31,21 @@ groups:
                   - path: /metrics/json/
                     format: json
                   - path: /metrics/observed/prometheus
+                    format: prometheus
+                    metrics:
+                      enabled: true
+                - endpoints:
+                  - path: /metrics/prometheus
+                    format: prometheus
+                  - path: /metrics/json
+                    format: json
+                - server: 'additional'
+                  endpoints:
+                  - path: /metrics/prometheus
+                    format: prometheus
+                  - path: /metrics/json
+                    format: json
+                  - path: /metrics/observed/prometheus/1
                     format: prometheus
                     metrics:
                       enabled: true

--- a/test/helpers/mocks.lua
+++ b/test/helpers/mocks.lua
@@ -1,0 +1,52 @@
+-- M is a mocks module that uses for changing methods behaviour.
+-- It could be useful in unit tests when we neeed to determine
+-- behaviour of methods that we don't need to test in it.
+local M = {}
+
+local validate = function(mocks)
+    if type(mocks) ~= "table" then
+        error("mocks should have a table type, got " .. type(mocks))
+    end
+
+    for _, mock in ipairs(mocks) do
+        if type(mock.module) ~= "string" then
+            error("module name should have a string type, got " .. type(mock.module))
+        end
+        local ok, _ = pcall(require, mock.module)
+        if not ok then
+            error("cannot require module " .. mock.module)
+        end
+
+        if type(mock.method) ~= "string" then
+            error("method name should have a string type, got " .. type(mock.method))
+        end
+        if require(mock.module)[mock.method] == nil then
+            error("there is no method called " .. mock.method .. " in " .. mock.module)
+        end
+
+        if type(mock.implementation) ~= "function" then
+            error("implementation type should be a function, got " .. mock.implementation)
+        end
+    end
+end
+
+-- M.apply validates mocks, initializes it and if everything
+-- is fine replaces methods from initialized list.
+M.apply = function(mocks)
+    validate(mocks)
+    M.mocks = mocks
+
+    for _, mock in ipairs(M.mocks) do
+        mock.original_implementation = require(mock.module)[mock.method]
+        require(mock.module)[mock.method] = mock.implementation
+    end
+end
+
+-- M.delete returns original implementation from mocked method.
+M.clear = function()
+    for _, mock in ipairs(M.mocks) do
+       require(mock.module)[mock.method] = mock.original_implementation
+    end
+end
+
+return M

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -99,13 +99,25 @@ g.test_endpoints = function()
     assert_json("http://127.0.0.1:8081/metrics/json/")
     assert_prometheus("http://127.0.0.1:8081/metrics/prometheus")
     assert_prometheus("http://127.0.0.1:8081/metrics/prometheus/")
+    assert_not_observed("http://127.0.0.1:8081", "/metrics/prometheus")
 
     assert_prometheus("http://127.0.0.1:8082/metrics/prometheus")
     assert_prometheus("http://127.0.0.1:8082/metrics/prometheus/")
     assert_json("http://127.0.0.1:8082/metrics/json")
     assert_json("http://127.0.0.1:8082/metrics/json/")
-
-    assert_not_observed("http://127.0.0.1:8081", "/metrics/prometheus")
     assert_not_observed("http://127.0.0.1:8082", "/metrics/prometheus")
     assert_observed("http://127.0.0.1:8082", "/metrics/observed/prometheus")
+
+    assert_prometheus("http://127.0.0.1:8085/metrics/prometheus")
+    assert_prometheus("http://127.0.0.1:8085/metrics/prometheus/")
+    assert_json("http://127.0.0.1:8085/metrics/json")
+    assert_json("http://127.0.0.1:8085/metrics/json/")
+    assert_not_observed("http://127.0.0.1:8085", "/metrics/prometheus")
+
+    assert_prometheus("http://127.0.0.1:8086/metrics/prometheus")
+    assert_prometheus("http://127.0.0.1:8086/metrics/prometheus/")
+    assert_json("http://127.0.0.1:8086/metrics/json")
+    assert_json("http://127.0.0.1:8086/metrics/json/")
+    assert_not_observed("http://127.0.0.1:8086", "/metrics/prometheus")
+    assert_observed("http://127.0.0.1:8086", "/metrics/observed/prometheus/1")
 end


### PR DESCRIPTION
Since the `httpd` role was released this role need to support this feature.

After the patch metrics-export-role supports an `httpd` role. It is possible to determine a list of servers that role will reuse in the following configuration.

Closes #15