### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Introduce latency observation for http endpoint (#17).
-- Support `roles.httpd` integration (#15).
 
 ### Fixed
 
 ### Changed
+
+## 0.2.0 - 2024-10-02
+
+The release introduces the integration with `httpd` role and latency observation for http
+endpoint. Now it is possible to [reuse server's address from `httpd` role config
+for `metrics-export-role` configuration](README.md#integration-with-httpd-role).
+
+### Added
+
+- Introduce latency observation for http endpoint (#17).
+- Support `roles.httpd` integration (#15).
 
 ## 0.1.0 - 2024-06-11
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from Tarantool 3. For now only export via HTTP is supported.
 ```Lua
 dependencies = {
     ...
-    'metrics-export-role == 0.1.0-1',
+    'metrics-export-role == 0.2.0-1',
     ...
 }
 ```

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -6,7 +6,7 @@ local M = {}
 
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
-M._VERSION = "0.1.0"
+M._VERSION = "0.2.0"
 
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")


### PR DESCRIPTION
The release introduces the integration with `httpd` role and latency observation for http endpoint. Now it is possible to reuse server's address from `httpd` role config for `metrics-export-role` configuration.

### Added

- Introduce latency observation for http endpoint (#17).
- Support `roles.httpd` integration (#15).