### PR TITLE
ci: add luacheck linter

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,36 @@
+name: Run static analysis
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-static-analysis:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Setup Tarantool CE
+      uses: tarantool/setup-tarantool@v3
+      with:
+        tarantool-version: '3.2.0'
+
+    - name: Setup tt
+      run: |
+        curl -L https://tarantool.io/release/3/installer.sh | sudo bash
+        sudo apt install -y tt
+        tt version
+
+    - name: Setup luacheck
+      run: make deps depname=lint
+
+    - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
+
+    - name: Run static analysis
+      run: make check

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -95,12 +95,10 @@ jobs:
           tt version
 
       - name: Install requirements
-        run: make deps
+        run: make deps depname=coverage
         if: steps.cache-rocks.outputs.cache-hit != 'true'
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
-
-      - run: make check
 
       - run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,24 @@ coveralls: $(LUACOV_STATS)
 	echo "Send code coverage data to the coveralls.io service"
 	luacov-coveralls --include ^roles --verbose --repo-token ${GITHUB_TOKEN}
 
-deps:
+deps-test:
 	tt rocks install luatest 1.0.1
-	tt rocks install luacheck 0.26.0
+
+deps-coverage: deps-test
 	tt rocks install luacov 0.13.0-1
 	tt rocks install luacov-coveralls 0.2.3-1 --server=http://luarocks.org
+
+deps-lint:
+	tt rocks install luacheck 0.26.0
+
+deps:
+ifeq ($(depname), test)
+	$(MAKE) deps-test
+else ifeq ($(depname), coverage)
+	$(MAKE) deps-coverage
+else ifeq ($(depname), lint)
+	$(MAKE) deps-lint
+else
+	$(MAKE) deps-coverage deps-lint
+endif
 	tt rocks make

--- a/README.md
+++ b/README.md
@@ -206,10 +206,30 @@ git clone https://github.com/tarantool/metrics-export-role
 cd metrics-export-role
 ```
 
-After that you need to install dependencies (`tt` is required):
+After that you need to install dependencies (`tt` is required).
+To do it, run:
 
 ```shell
 make deps
+```
+
+It's possible to install requirements only for running tests
+or linter check. To install only tests requirements, run:
+
+```shell
+make deps depname=test
+```
+
+To install tests with coverage requirements, run:
+
+```shell
+make deps depname=coverage
+```
+
+To install linter checks, run:
+
+```shell
+make deps depname=lint
 ```
 
 At this point you could run tests (`tarantool` 3 is required):


### PR DESCRIPTION
There was a linter check in test in `testing` workflow, but not in a separate job.

After the patch a linter check is available in a separate job and the previous step from `testing` workflow was deleted.

Closes #21