### PR TITLE
rockspec: update tarantool version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update Tarantool dependency to `>=3.0.2` (#25).
+
 ### Changed
 
 ## 0.2.0 - 2024-10-02

--- a/metrics-export-role-scm-1.rockspec
+++ b/metrics-export-role-scm-1.rockspec
@@ -15,7 +15,7 @@ description = {
 
 dependencies = {
     "lua >= 5.1",
-    "tarantool >= 3.0",
+    "tarantool >= 3.0.2",
     "http >= 1.5.0",
 }
 


### PR DESCRIPTION
`config:get` method inside roles doesn't work properly on Tarantool 3.0.1.

Update tarantool dependency to the `>=3.0.2` version, so the `config:get()` works without problems.

Closes #25