### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## 0.3.0 - 2024-12-27
+
+This release adds TLS support with `listen` configuration parameter.
+
+### Added
+
 - Support TLS for `listen` parameter (#26).
 
 ### Fixed
 
 - Update Tarantool dependency to `>=3.0.2` (#25).
-
-### Changed
 
 ## 0.2.0 - 2024-10-02
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from Tarantool 3. For now only export via HTTP is supported.
 ```Lua
 dependencies = {
     ...
-    'metrics-export-role == 0.2.0-1',
+    'metrics-export-role == 0.3.0-1',
     ...
 }
 ```

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -6,7 +6,7 @@ local M = {}
 
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
-M._VERSION = "0.2.0"
+M._VERSION = "0.3.0"
 
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")


### PR DESCRIPTION
This release adds TLS support with `listen` configuration parameter.

### Added

- Support TLS for `listen` parameter (#26).

### Fixed

- Update Tarantool dependency to `>=3.0.2` (#25).

