### PR TITLE
[wip] fix: content-type header for metrics endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tags
 doc/apidoc/
 .idea
 *.swp
+.DS_Store

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -100,7 +100,15 @@ end
 local http_handlers = {
     json = function(req)
         local json_exporter = require('metrics.plugins.json')
-        return req:render({ text = json_exporter.export() })
+        local json_data = json_exporter.export()
+
+        if type(json_data) ~= "string" then
+            json_data = require('json').encode(json_data)
+        end
+
+        local response = req:render({ json = {} })
+        response.body = json_data
+        return response
     end,
     prometheus = function(...)
         local http_handler = require('metrics.plugins.prometheus').collect_http

--- a/test/unit/http_test.lua
+++ b/test/unit/http_test.lua
@@ -1140,3 +1140,53 @@ for name, case in pairs(test_tls_cases) do
         end
     end
 end
+
+local function assert_content_type(uri, expected_content_type, tls_opts)
+    local response = http_client:get(uri, tls_opts)
+    t.assert_equals(response.status, 200)
+    t.assert_equals(response.headers['content-type'], expected_content_type)
+end
+
+local test_content_type_cases = {
+    ['json'] = {
+        cfg = {
+            http = {
+                {
+                    listen = 8081,
+                    endpoints = {
+                        {
+                            path = "/json_metrics",
+                            format = "json",
+                        },
+                    },
+                },
+            },
+        },
+        expected_url = "http://127.0.0.1:8081/json_metrics",
+        expected_content_type = "application/json; charset=utf-8",
+    },
+    ['prometheus'] = {
+        cfg = {
+            http = {
+                {
+                    listen = 8081,
+                    endpoints = {
+                        {
+                            path = "/prometheus_metrics",
+                            format = "prometheus",
+                        },
+                    },
+                },
+            },
+        },
+        expected_url = "http://127.0.0.1:8081/prometheus_metrics",
+        expected_content_type = "text/plain; charset=utf8",
+    },
+}
+
+for name, case in pairs(test_content_type_cases) do
+    g['test_content_type_' .. name] = function(cg)
+        cg.role.apply(case.cfg)
+        assert_content_type(case.expected_url, case.expected_content_type)
+    end
+end


### PR DESCRIPTION
Issue #13:
- JSON endpoints now return the correct Content-Type: `application/json; charset=utf-8`.

Additionally:
- Added tests to verify the correctness of the Content-Type header.

This fix ensures proper header formatting and alignment with client expectations.