### PR TITLE
ci: add separate coverage job

### DIFF
--- a/.github/actions/install-tarantool/action.yml
+++ b/.github/actions/install-tarantool/action.yml
@@ -1,0 +1,62 @@
+name: "Download and install Tarantool"
+description: "Download Tarantool with provided version using 'tarantool/setup-tarantool' action
+              or install and build it manually with debug branch."
+
+inputs:
+  tarantool:
+    required: true
+    type: string
+  
+runs:
+  using: "composite"
+  steps:
+    - name: Install tarantool ${{ inputs.tarantool }} (dynamic)
+      if: startsWith(inputs.tarantool, 'debug') != true
+      shell: bash
+      run: tt install tarantool ${{ inputs.tarantool }} --dynamic
+
+    - name: Create variables for Tarantool ${{ inputs.tarantool }}
+      if: startsWith(inputs.tarantool, 'debug')
+      run: |
+        branch=$(echo ${{ inputs.tarantool }} | cut -d- -f2)
+        commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch ${branch} | head -c 8)
+        echo "TNT_BRANCH=${branch}" >> $GITHUB_ENV
+        echo "VERSION_POSTFIX=-${commit_hash}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Cache tarantool build
+      if: startsWith(inputs.tarantool, 'debug')
+      id: cache-tnt-debug
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.TNT_DEBUG_PATH }}
+        key: cache-tnt-${{ inputs.tarantool }}${{ env.VERSION_POSTFIX }}
+
+    - name: Clone tarantool ${{ inputs.tarantool }}
+      if: startsWith(inputs.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: tarantool/tarantool
+        ref: ${{ env.TNT_BRANCH }}
+        path: tarantool
+        fetch-depth: 0
+        submodules: true
+
+    - name: Build tarantool ${{ inputs.tarantool }}
+      if: startsWith(inputs.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        sudo apt-get -y install git build-essential cmake make zlib1g-dev \
+          libreadline-dev libncurses5-dev libssl-dev \
+          libunwind-dev libicu-dev python3 python3-yaml \
+          python3-six python3-gevent
+        cd ${GITHUB_WORKSPACE}/tarantool
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_DIST=ON
+        make
+        make DESTDIR=${TNT_DEBUG_PATH} install
+
+    - name: Install tarantool ${{ inputs.tarantool }} (debug)
+      if: startsWith(inputs.tarantool, 'debug')
+      shell: bash
+      run: sudo cp -rvP ${TNT_DEBUG_PATH}/usr/local/* /usr/local/

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux:
+  tests:
     # We want to run on external PRs, but not on our own internal
     # PRs as they'll be run by the push to the branch.
     #
@@ -21,7 +21,6 @@ jobs:
           - 'debug-master'
         include:
           - tarantool: '3.1'
-            coveralls: true
     env:
       TNT_DEBUG_PATH: /home/runner/tnt-debug
 
@@ -49,15 +48,57 @@ jobs:
           key: "cache-rocks-${{ matrix.tarantool }}${{ env.VERSION_POSTFIX }}"
 
       - name: Install requirements
-        run: make deps depname=coverage
+        run: make deps depname=test
         if: steps.cache-rocks.outputs.cache-hit != 'true'
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 
       - run: make test
 
+  coverage:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+
+    env:
+      TNT_DEBUG_PATH: /home/runner/tnt-debug
+
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone the module
+        uses: actions/checkout@v3
+
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/3/installer.sh | bash
+          sudo apt install -y tt
+          tt version
+
+      - name: Install Tarantool
+        uses: ./.github/actions/install-tarantool
+        with: 
+          tarantool: '3.1'
+
+      - name: Cache rocks
+        uses: actions/cache@v3
+        id: cache-rocks
+        with:
+          path: .rocks/
+          key: "cache-rocks-3.1${{ env.VERSION_POSTFIX }}"
+
+      - name: Install requirements
+        run: make deps depname=coverage
+        if: steps.cache-rocks.outputs.cache-hit != 'true'
+
+      - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
+
       - name: Send code coverage to 'coveralls.io'
         run: make coveralls
-        if: ${{ matrix.coveralls }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -27,63 +27,19 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
+      - name: Clone the module
+        uses: actions/checkout@v3
+
       - name: Setup tt
         run: |
           curl -L https://tarantool.io/release/3/installer.sh | bash
           sudo apt install -y tt
           tt version
 
-      - name: Install tarantool ${{ matrix.tarantool }}
-        if: startsWith(matrix.tarantool, 'debug') != true
-        run: tt install tarantool ${{ matrix.tarantool }} --dynamic
-
-      - name: Create variables for Tarantool ${{ matrix.tarantool }}
-        if: startsWith(matrix.tarantool, 'debug')
-        run: |
-          branch=$(echo ${{ matrix.tarantool }} | cut -d- -f2)
-          commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch ${branch} | head -c 8)
-          echo "TNT_BRANCH=${branch}" >> $GITHUB_ENV
-          echo "VERSION_POSTFIX=-${commit_hash}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Cache tarantool build
-        if: startsWith(matrix.tarantool, 'debug')
-        id: cache-tnt-debug
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.TNT_DEBUG_PATH }}
-          key: cache-tnt-${{ matrix.tarantool }}${{ env.VERSION_POSTFIX }}
-
-      - name: Clone tarantool ${{ matrix.tarantool }}
-        if: startsWith(matrix.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: tarantool/tarantool
-          ref: ${{ env.TNT_BRANCH }}
-          path: tarantool
-          fetch-depth: 0
-          submodules: true
-
-      - name: Build tarantool ${{ matrix.tarantool }}
-        if: startsWith(matrix.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get -y install git build-essential cmake make zlib1g-dev \
-            libreadline-dev libncurses5-dev libssl-dev \
-            libunwind-dev libicu-dev python3 python3-yaml \
-            python3-six python3-gevent
-          cd ${GITHUB_WORKSPACE}/tarantool
-          mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_DIST=ON
-          make
-          make DESTDIR=${TNT_DEBUG_PATH} install
-
-      - name: Install tarantool ${{ matrix.tarantool }}
-        if: startsWith(matrix.tarantool, 'debug')
-        run: |
-          sudo cp -rvP ${TNT_DEBUG_PATH}/usr/local/* /usr/local/
-
-      - name: Clone the module
-        uses: actions/checkout@v3
+      - name: Install Tarantool
+        uses: ./.github/actions/install-tarantool
+        with: 
+          tarantool: ${{ matrix.tarantool }}
 
       - name: Cache rocks
         uses: actions/cache@v3

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -42,13 +42,6 @@ jobs:
         with: 
           tarantool: ${{ matrix.tarantool }}
 
-      - name: Cache rocks
-        uses: actions/cache@v3
-        id: cache-rocks
-        with:
-          path: .rocks/
-          key: "cache-rocks-${{ matrix.tarantool }}${{ env.VERSION_POSTFIX }}"
-
       - name: Install requirements
         run: make deps depname=test
         if: steps.cache-rocks.outputs.cache-hit != 'true'
@@ -86,13 +79,6 @@ jobs:
         uses: ./.github/actions/install-tarantool
         with: 
           tarantool: '3.3'
-
-      - name: Cache rocks
-        uses: actions/cache@v3
-        id: cache-rocks
-        with:
-          path: .rocks/
-          key: "cache-rocks-3.1${{ env.VERSION_POSTFIX }}"
 
       - name: Install requirements
         run: make deps depname=coverage

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,7 +20,9 @@ jobs:
         tarantool:
           - 'debug-master'
         include:
-          - tarantool: '3.1'
+          # We test role for min supported tarantool version and the latest one.
+          - tarantool: '3.0.2'
+          - tarantool: '3.3.1'
     env:
       TNT_DEBUG_PATH: /home/runner/tnt-debug
 
@@ -83,7 +85,7 @@ jobs:
       - name: Install Tarantool
         uses: ./.github/actions/install-tarantool
         with: 
-          tarantool: '3.1'
+          tarantool: '3.3'
 
       - name: Cache rocks
         uses: actions/cache@v3


### PR DESCRIPTION
Running tests, collecting the coverage and sending it to the coveralls was in a single job. After the patch tests, whether ran with and without coverage, were separated.

Closes #22