### PR TITLE
api: return reasonable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Unclear error message when `roles.httpd` config is not applied yet (#33).
+
 ## 0.3.0 - 2024-12-27
 
 This release adds TLS support with `listen` configuration parameter.

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -369,6 +369,10 @@ local function apply_http(conf)
                     httpd:start()
                 else
                     httpd = httpd_role.get_server(target.value)
+                    if httpd == nil then
+                        error(('failed to get server by name %q, check that roles.httpd was' ..
+                              ' already applied'):format(target.value))
+                    end
                 end
 
                 http_servers[tostring(target.value) .. tostring(target.is_httpd_role)] = {

--- a/test/entrypoint/incorrect_roles_sequence.yaml
+++ b/test/entrypoint/incorrect_roles_sequence.yaml
@@ -1,0 +1,27 @@
+credentials:
+  users:
+    guest:
+      roles: [super]
+
+groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        instances:
+          master:
+            roles: [roles.metrics-export, roles.httpd]
+            roles_cfg:
+              roles.httpd:
+                default:
+                  listen: 8085
+              roles.metrics-export:
+                http:
+                - server: 'default'
+                  endpoints:
+                  - path: /metrics/prometheus
+                    format: prometheus
+                    metrics:
+                      enabled: true
+            iproto:
+              listen:
+                - uri: '127.0.0.1:3313'

--- a/test/integration/error_test.lua
+++ b/test/integration/error_test.lua
@@ -1,0 +1,40 @@
+local fio = require('fio')
+local helpers = require('test.helpers')
+local server = require('test.helpers.server')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    helpers.skip_if_unsupported()
+end)
+
+g.before_each(function(cg)
+    cg.workdir = fio.tempdir()
+    fio.mktree(cg.workdir)
+
+    fio.copytree(".rocks", fio.pathjoin(cg.workdir, ".rocks"))
+    fio.copytree("roles", fio.pathjoin(cg.workdir, "roles"))
+end)
+
+g.after_each(function(cg)
+    fio.rmtree(cg.workdir)
+end)
+
+g.test_incorrect_httpd_sequense = function(cg)
+    cg.server = server:new({
+            config_file = fio.abspath(fio.pathjoin('test', 'entrypoint', 'incorrect_roles_sequence.yaml')),
+            chdir = cg.workdir,
+            alias = 'master',
+            workdir = cg.workdir,
+    })
+
+    t.assert_error(function()
+        cg.server:start({wait_until_ready = true})
+    end)
+
+    t.assert_str_contains(
+        cg.server.process.output_beautifier.stderr,
+        'failed to get server by name "default", check that roles.httpd was already applied'
+    )
+end


### PR DESCRIPTION
There was "attempt to index local 'httpd' (a nil value)" error that doesn't get any useful information.

This patch adds readable error message that tells you to check if the roles are properly included in the sequence.

Closes #33