### PR TITLE
api: fix address already in use error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Address already in use` error on change role's config on the fly (#34).
+
 ### Changed
 
 - Unclear error message when `roles.httpd` config is not applied yet (#33).

--- a/test/integration/reload_config_test.lua
+++ b/test/integration/reload_config_test.lua
@@ -1,0 +1,102 @@
+local fio = require('fio')
+local yaml = require('yaml')
+local socket = require('socket')
+local helpers = require('test.helpers')
+local server = require('test.helpers.server')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function()
+    helpers.skip_if_unsupported()
+end)
+
+g.before_each(function(cg)
+    cg.workdir = fio.tempdir()
+    fio.mktree(cg.workdir)
+
+    fio.copytree(".rocks", fio.pathjoin(cg.workdir, ".rocks"))
+    fio.copytree("roles", fio.pathjoin(cg.workdir, "roles"))
+    fio.copytree(fio.pathjoin("test", "ssl_data"), fio.pathjoin(cg.workdir, "ssl_data"))
+    fio.copyfile(fio.pathjoin('test', 'entrypoint', 'config.yaml'), cg.workdir)
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    fio.rmtree(cg.workdir)
+end)
+
+local function is_tcp_connect(host, port)
+    local tcp = socket.tcp()
+    tcp:settimeout(0.3)
+    local ok, _ = tcp:connect(host, port)
+    tcp:close()
+
+    return ok
+end
+
+local function change_listen_target_in_config(cg, old_addr, new_addr)
+    local file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_RDONLY'})
+    t.assert(file ~= nil)
+
+    local cfg = file:read()
+    file:close()
+
+    cfg = yaml.decode(cfg)
+    local export_instances = cfg.groups['group-001'].replicasets['replicaset-001'].
+                             instances.master.roles_cfg['roles.metrics-export'].http
+
+    for i, v in pairs(export_instances) do
+        if v.listen ~= nil and v.listen == old_addr then
+            export_instances[i].listen = new_addr
+        end
+    end
+
+    file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}, tonumber('644', 8))
+    file:write(yaml.encode(cfg))
+    file:close()
+end
+
+g.test_reload_config_update_addr = function(cg)
+    cg.server = server:new({
+        config_file = fio.pathjoin(cg.workdir, 'config.yaml'),
+        chdir = cg.workdir,
+        alias = 'master',
+        workdir = cg.workdir,
+    })
+
+    cg.server:start({wait_until_ready = true})
+
+    t.assert(is_tcp_connect('127.0.0.1', 8082))
+    t.assert_not(is_tcp_connect('127.0.0.2', 8082))
+
+    change_listen_target_in_config(cg, '127.0.0.1:8082', '0.0.0.0:8082')
+    cg.server:eval("require('config'):reload()")
+
+    t.assert(is_tcp_connect('127.0.0.1', 8082))
+    t.assert(is_tcp_connect('127.0.0.2', 8082))
+    t.assert(is_tcp_connect('127.1.2.3', 8082))
+
+    change_listen_target_in_config(cg, '0.0.0.0:8082', '127.0.0.1:8082')
+    cg.server:eval("require('config'):reload()")
+
+    t.assert_not(is_tcp_connect('127.0.0.2', 8082))
+    t.assert(is_tcp_connect('127.0.0.1', 8082))
+end
+
+g.test_reload_config_global_addr_conflict = function(cg)
+    cg.server = server:new({
+        config_file = fio.pathjoin(cg.workdir, 'config.yaml'),
+        chdir = cg.workdir,
+        alias = 'master',
+        workdir = cg.workdir,
+    })
+
+    cg.server:start({wait_until_ready = true})
+
+    change_listen_target_in_config(cg, 8081, '0.0.0.0:8082')
+    t.assert_error_msg_content_equals(
+      "Can't create tcp_server: Address already in use",
+      function() cg.server:eval("require('config'):reload()") end
+    )
+end

--- a/test/unit/http_test.lua
+++ b/test/unit/http_test.lua
@@ -699,6 +699,57 @@ local test_reapply_delete_cases = {
             },
         },
     },
+    ["listen_global_addr"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    http = {
+                        {
+                            listen = '0.0.0.0:8081',
+                            endpoints = {
+                                {
+                                    path = "/metrics1",
+                                    format = "prometheus",
+                                },
+                            },
+                        },
+                    },
+                },
+                expected_json_urls = {},
+                expected_prometheus_urls = {
+                    "http://127.0.0.1:8081/metrics1",
+                    "http://127.1.2.3:8081/metrics1"
+                },
+                expected_none_urls = {},
+            },
+            {
+                cfg = {
+                    http = {
+                        {
+                            listen = '127.0.0.1:8081',
+                            endpoints = {
+                                {
+                                    path = "/metrics1",
+                                    format = "json",
+                                },
+                                {
+                                    path = "/metrics2",
+                                    format = "prometheus",
+                                },
+                            },
+                        },
+                    },
+                },
+                expected_json_urls = {
+                    "http://127.0.0.1:8081/metrics1",
+                },
+                expected_prometheus_urls = {
+                    "http://127.0.0.1:8081/metrics2",
+                },
+                expected_none_urls = {},
+            },
+        },
+    },
 }
 
 for name, case in pairs(test_reapply_delete_cases) do
@@ -855,6 +906,61 @@ local test_reapply_add_cases = {
                 module = "config",
                 method = "get",
                 implementation = config_get_return_httpd_config,
+            },
+        },
+    },
+    ["listen_global_addr"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    http = {
+                        {
+                            listen = '127.0.0.1:8081',
+                            endpoints = {
+                                {
+                                    path = "/metrics1",
+                                    format = "prometheus",
+                                },
+                            },
+                        },
+                    },
+                },
+                expected_json_urls = {},
+                expected_prometheus_urls = {
+                    "http://127.0.0.1:8081/metrics1"
+                },
+                expected_none_urls = {
+                    "http://127.0.0.1:8081/metrics2",
+                    "http://127.0.0.1:8082/metrics1",
+                },
+            },
+            {
+                cfg = {
+                    http = {
+                        {
+                            listen = '0.0.0.0:8081',
+                            endpoints = {
+                                {
+                                    path = "/metrics1",
+                                    format = "json",
+                                },
+                                {
+                                    path = "/metrics2",
+                                    format = "prometheus",
+                                },
+                            },
+                        },
+                    },
+                },
+                expected_json_urls = {
+                    "http://127.0.0.1:8081/metrics1",
+                    "http://127.1.2.3:8081/metrics1",
+                },
+                expected_prometheus_urls = {
+                    "http://127.0.0.1:8081/metrics2",
+                    "http://127.1.2.3:8081/metrics2",
+                },
+                expected_none_urls = {},
             },
         },
     },


### PR DESCRIPTION
There was a bug when user wants to change server's `listen` address and reload config on the fly - error `address already in use` occures.

This patch reworks server's address handling by applying roles' config.

Closes #34