### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Changed
+
+## 0.3.1 - 2025-07-07
+
+The release contains some minor bugfixes.
+
+### Fixed
+
 - `Address already in use` error on change role's config on the fly (#34).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from Tarantool 3. For now only export via HTTP is supported.
 ```Lua
 dependencies = {
     ...
-    'metrics-export-role == 0.3.0-1',
+    'metrics-export-role == 0.3.1-1',
     ...
 }
 ```

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -6,7 +6,7 @@ local M = {}
 
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
-M._VERSION = "0.3.0"
+M._VERSION = "0.3.1"
 
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")


### PR DESCRIPTION
The release contains some minor bugfixes.

### Fixed

- `Address already in use` error on change role's config on the fly (#34).

### Changed

- Unclear error message when `roles.httpd` config is not applied yet (#33).
