### PR TITLE
graphite: configuration design

### DIFF
--- a/.github/actions/install-tarantool/action.yml
+++ b/.github/actions/install-tarantool/action.yml
@@ -27,14 +27,14 @@ runs:
     - name: Cache tarantool build
       if: startsWith(inputs.tarantool, 'debug')
       id: cache-tnt-debug
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ env.TNT_DEBUG_PATH }}
         key: cache-tnt-${{ inputs.tarantool }}${{ env.VERSION_POSTFIX }}
 
     - name: Clone tarantool ${{ inputs.tarantool }}
       if: startsWith(inputs.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: tarantool/tarantool
         ref: ${{ env.TNT_BRANCH }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Setup Tarantool CE
-      uses: tarantool/setup-tarantool@v3
+      uses: tarantool/setup-tarantool@v4
       with:
-        tarantool-version: '3.2.0'
+        tarantool-version: '3.6.0'
 
     - name: Setup tt
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,12 @@ jobs:
       # We can not use 'tarantool/check-module-version' action since it installs Tarantool 2.10.
       # For this module we need Tarantool 3.
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install tarantool 3.1
-        uses: tarantool/setup-tarantool@v3
+      - name: Install tarantool 3.6
+        uses: tarantool/setup-tarantool@v4
         with:
-          tarantool-version: '3.1'
+          tarantool-version: '3.6'
 
       - name: Setup tt
         run: |
@@ -50,7 +50,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -61,7 +61,7 @@ jobs:
     needs: version-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,7 @@ jobs:
         include:
           # We test role for min supported tarantool version and the latest one.
           - tarantool: '3.0.2'
-          - tarantool: '3.3.1'
+          - tarantool: '3.6.2'
     env:
       TNT_DEBUG_PATH: /home/runner/tnt-debug
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tt
         run: |
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tt
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Install Tarantool
         uses: ./.github/actions/install-tarantool
         with: 
-          tarantool: '3.3'
+          tarantool: '3.6'
 
       - name: Install requirements
         run: make deps depname=coverage

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ groups:
                     format: prometheus
                   - path: /metrics/json/
                     format: json
+                graphite:
+                - prefix: 'tarantool'
+                  host: '127.0.0.1'
+                  port: 2003
+                  send_interval: 1
 ```
 
 In the example above, we configure four HTTP servers. There are serveral server fields:
@@ -183,6 +188,27 @@ roles_cfg:
         format: prometheus
         metrics:
           enabled: true
+```
+
+### graphite target
+
+The target allows exporting metrics to Graphite servers and can be configured
+as an array of servers.
+
+Each server must have `host` and `port` parameters (IP and port number
+of a Graphite server), a `prefix` to export metrics in the format <prefix>.<metric_name>,
+and optional parameter `send_interval` with default value 1 sec.
+
+An individual server can be described as:
+
+```yaml
+roles_cfg:
+  roles.metrics-export:
+    graphite:
+    - prefix: 'tarantool'
+      host: '127.0.0.1'
+      port: 2003
+      send_interval: 1
 ```
 
 ### TLS support

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -8,6 +8,8 @@ local M = {}
 -- Requires manual update in case of release commit.
 M._VERSION = "0.3.2"
 
+local DEFAULT_GRAPHITE_SEND_INTERVAL = 2
+
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")
     for k, _ in pairs(tbl) do
@@ -107,6 +109,7 @@ local http_handlers = {
         return http_handler(...)
     end,
 }
+
 -- It is used as an error string with the predefined order.
 local http_supported_formats_str = "json, prometheus"
 
@@ -122,6 +125,76 @@ local function validate_endpoint_metrics(metrics)
     if metrics.enabled ~= nil and type(metrics.enabled) ~= 'boolean' then
         error("http endpoint metrics 'enabled' must be a boolean, got " .. type(metrics.enabled), 5)
     end
+end
+
+local function validate_graphite_port(port)
+    if port == nil then
+        error("graphite must have 'port'", 4)
+    end
+    if type(port) ~= "number" then
+        error("graphite 'port' must be a 'number', got " .. type(port), 4)
+    elseif port < 0 or port > 65535 then
+        error("graphite 'port' must be a valid port (0..65535), got " .. tostring(port), 4)
+    end
+end
+
+local function validate_graphite_send_interval(endpoint)
+    if endpoint.send_interval == nil then
+        endpoint.send_interval = DEFAULT_GRAPHITE_SEND_INTERVAL
+        return
+    elseif type(endpoint.send_interval) ~= "number" then
+        error("graphite 'send_interval' must be a 'number', got " .. type(endpoint.send_interval), 4)
+    elseif endpoint.send_interval <= 0 then
+        error("graphite 'send_interval' must be a positive number, got " .. tostring(endpoint.send_interval), 4)
+    end
+end
+
+local function validate_graphite_node(endpoint)
+    if type(endpoint) ~= "table" then
+        error("graphite node must be a table, got " .. type(endpoint), 4)
+    end
+    if next(endpoint) == nil then
+        error("graphite node must have configuration", 4)
+    end
+    if endpoint.prefix == nil then
+        error("graphite must have 'prefix'", 4)
+    end
+    if type(endpoint.prefix) ~= "string" then
+        error("graphite 'prefix' must be a 'string', got " .. type(endpoint.prefix), 4)
+    end
+    if endpoint.host == nil then
+        error("graphite must have 'host'", 4)
+    end
+    if type(endpoint.host) ~= "string" then
+        error("graphite 'host' must be a 'string', got " .. type(endpoint.host), 4)
+    end
+
+    validate_graphite_port(endpoint.port)
+
+    validate_graphite_send_interval(endpoint)
+end
+
+local function validate_graphite(conf)
+    if conf ~= nil and type(conf) ~= "table" then
+        error("graphite configuration must be a table, got " .. type(conf), 2)
+    end
+    conf = conf or {}
+
+    if not is_array(conf) then
+        error("graphite configuration must be an array, not a map", 2)
+    end
+
+    for _, graphite_node in ipairs(conf) do
+        validate_graphite_node(graphite_node)
+    end
+end
+
+local function apply_graphite()
+    -- Will be implemented in the next PR.
+end
+
+local function stop_graphite()
+    -- Will be implemented in the next PR.
 end
 
 local function validate_http_endpoint(endpoint)
@@ -470,6 +543,11 @@ local export_targets = {
         validate = validate_http,
         apply = apply_http,
         stop = stop_http,
+    },
+    ["graphite"] = {
+        validate = validate_graphite,
+        apply = apply_graphite,
+        stop = stop_graphite,
     },
 }
 

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -17,6 +17,14 @@ groups:
                 additional:
                   listen: '127.0.0.1:8086'
               roles.metrics-export:
+                graphite:
+                - prefix: 'master'
+                  host: '127.0.0.1'
+                  port: 2222
+                  send_interval: 1
+                - prefix: 'tarantool'
+                  host: '127.0.0.1'
+                  port: 2223
                 http:
                 - listen: 8081
                   endpoints:

--- a/test/unit/validate_test.lua
+++ b/test/unit/validate_test.lua
@@ -629,6 +629,144 @@ local error_cases = {
         },
         err = "tls options are availabe only with 'listen' parameter",
     },
+    ["graphite_not_a_table"] = {
+        cfg = {
+            graphite = 123,
+        },
+        err = "graphite configuration must be a table, got number"
+    },
+    ["graphite_node_not_a_table"] = {
+        cfg = {
+            graphite = {
+                123,456
+            },
+        },
+        err = "graphite node must be a table, got number"
+    },
+    ["graphite_no_params"] = {
+        cfg = {
+            graphite = {{}},
+        },
+        err = "graphite node must have configuration"
+    },
+    ["graphite_no_prefix"] = {
+        cfg = {
+            graphite = {{
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'prefix'"
+    },
+    ["graphite_prefix_invalid"] = {
+        cfg = {
+            graphite = {{
+                prefix = 123,
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'prefix' must be a 'string', got number"
+    },
+    ["graphite_no_host"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'host'"
+    },
+    ["graphite_host_invalid"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = 123,
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'host' must be a 'string', got number"
+    },
+    ["graphite_no_port"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'port'"
+    },
+    ["graphite_port_string"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = '2222',
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a 'number', got string"
+    },
+    ["graphite_port_negative"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = -2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a valid port (0..65535), got "
+    },
+    ["graphite_port_overflow"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 111222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a valid port (0..65535), got "
+    },
+    ["graphite_send_interval_string"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = '1',
+            },},
+        },
+        err = "graphite 'send_interval' must be a 'number', got string"
+    },
+    ["graphite_send_interval_negative"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = -1,
+            },},
+        },
+        err = "graphite 'send_interval' must be a positive number"
+    },
+    ["graphite_send_interval_zero"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 0,
+            },},
+        },
+        err = "graphite 'send_interval' must be a positive number"
+    },
 }
 
 for name, case in pairs(error_cases) do
@@ -892,6 +1030,41 @@ local ok_cases = {
                     ssl_password_file = "ssl_password_file",
                 },
             },
+        },
+    },
+    ["graphite_full"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+    },
+    ["graphite_no_send_interval"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+            },},
+        },
+    },
+    ["graphite_two_servers"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },
+            {
+                prefix = "tarantool",
+                host = "127.0.0.1",
+                port = 2223,
+                send_interval = 3,
+            },},
         },
     },
 }


### PR DESCRIPTION
This patch introduces configuration design for `graphite` targets, validation tests and `ci` updates.

Graphite target allows exporting metrics to Graphite servers and can be configured as an array of servers.

Each server must have `host` and `port` parameters (Graphite server IP and port number), `prefix` to export metrics in the format `<prefix>.<metric_name>`, and optional parameter `send_interval` with default value 1 sec.

An individual server can be described as:

```yaml
roles_cfg:
  roles.metrics-export:
    graphite:
    - prefix: 'tarantool'
      host: '127.0.0.1'
      port: 2003
      send_interval: 1
```

Closes #TNTP-6582