### PR TITLE
export: added graphite support

### DIFF
--- a/.github/actions/install-tarantool/action.yml
+++ b/.github/actions/install-tarantool/action.yml
@@ -27,14 +27,14 @@ runs:
     - name: Cache tarantool build
       if: startsWith(inputs.tarantool, 'debug')
       id: cache-tnt-debug
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ env.TNT_DEBUG_PATH }}
         key: cache-tnt-${{ inputs.tarantool }}${{ env.VERSION_POSTFIX }}
 
     - name: Clone tarantool ${{ inputs.tarantool }}
       if: startsWith(inputs.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: tarantool/tarantool
         ref: ${{ env.TNT_BRANCH }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Setup Tarantool CE
-      uses: tarantool/setup-tarantool@v3
+      uses: tarantool/setup-tarantool@v4
       with:
-        tarantool-version: '3.2.0'
+        tarantool-version: '3.6.0'
 
     - name: Setup tt
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,12 @@ jobs:
       # We can not use 'tarantool/check-module-version' action since it installs Tarantool 2.10.
       # For this module we need Tarantool 3.
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install tarantool 3.1
-        uses: tarantool/setup-tarantool@v3
+      - name: Install tarantool 3.6
+        uses: tarantool/setup-tarantool@v4
         with:
-          tarantool-version: '3.1'
+          tarantool-version: '3.6'
 
       - name: Setup tt
         run: |
@@ -50,7 +50,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -61,7 +61,7 @@ jobs:
     needs: version-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,7 @@ jobs:
         include:
           # We test role for min supported tarantool version and the latest one.
           - tarantool: '3.0.2'
-          - tarantool: '3.3.1'
+          - tarantool: '3.6.2'
     env:
       TNT_DEBUG_PATH: /home/runner/tnt-debug
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tt
         run: |
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tt
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Install Tarantool
         uses: ./.github/actions/install-tarantool
         with: 
-          tarantool: '3.3'
+          tarantool: '3.6'
 
       - name: Install requirements
         run: make deps depname=coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ability to export `graphite` metrics.
+
 ### Fixed
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ The target allows exporting metrics to Graphite servers and can be configured
 as an array of servers.
 
 Each server must have `host` and `port` parameters (IP and port number
-of a Graphite server), a `prefix` to export metrics in the format <prefix>.<metric_name>,
-and optional parameter `send_interval` with default value 1 sec.
+of a Graphite server), a `prefix` to export metrics in the format
+`<prefix>.<metric_name>`, and optional parameter `send_interval` with
+default value 2 sec.
 
 An individual server can be described as:
 
@@ -209,6 +210,9 @@ roles_cfg:
       host: '127.0.0.1'
       port: 2003
       send_interval: 1
+    - prefix: 'master'
+      host: '127.0.0.2'
+      port: 4444
 ```
 
 ### TLS support

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ groups:
                     format: prometheus
                   - path: /metrics/json/
                     format: json
+                graphite:
+                - prefix: 'tarantool'
+                  host: '127.0.0.1'
+                  port: 2003
+                  send_interval: 1
 ```
 
 In the example above, we configure four HTTP servers. There are serveral server fields:
@@ -183,6 +188,27 @@ roles_cfg:
         format: prometheus
         metrics:
           enabled: true
+```
+
+### graphite target
+
+The target allows exporting metrics to Graphite servers and can be configured
+as an array of servers.
+
+Each server must have `host` and `port` parameters (IP and port number
+of a Graphite server), a `prefix` to export metrics in the format <prefix>.<metric_name>,
+and optional parameter `send_interval` with default value 1 sec.
+
+An individual server can be described as:
+
+```yaml
+roles_cfg:
+  roles.metrics-export:
+    graphite:
+    - prefix: 'tarantool'
+      host: '127.0.0.1'
+      port: 2003
+      send_interval: 1
 ```
 
 ### TLS support

--- a/metrics-export-role-scm-1.rockspec
+++ b/metrics-export-role-scm-1.rockspec
@@ -17,6 +17,7 @@ dependencies = {
     "lua >= 5.1",
     "tarantool >= 3.0.2",
     "http >= 1.7.0",
+    "metrics == scm-1"
 }
 
 build = {

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -133,8 +133,8 @@ local function validate_graphite_port(port)
     end
     if type(port) ~= "number" then
         error("graphite 'port' must be a 'number', got " .. type(port), 4)
-    elseif port < 0 or port > 65535 then
-        error("graphite 'port' must be a valid port (0..65535), got " .. tostring(port), 4)
+    elseif port < 1 or port > 65535 then
+        error("graphite 'port' must be a valid port (1..65535), got " .. tostring(port), 4)
     end
 end
 
@@ -189,12 +189,58 @@ local function validate_graphite(conf)
     end
 end
 
-local function apply_graphite()
-    -- Will be implemented in the next PR.
+local function table_equals(t1, t2)
+	if t1 == t2 then
+        return true
+    end
+    if type(t1) ~= "table" or type(t2) ~= "table" then
+        return false
+    end
+
+    for k, v in pairs(t1) do
+        if type(v) == "table" and type(t2[k]) == "table" then
+            if not table_equals(v, t2[k]) then
+                return false
+            end
+        elseif v ~= t2[k] then
+            return false
+        end
+    end
+
+    for k in pairs(t2) do
+        if t1[k] == nil then
+            return false
+        end
+    end
+
+    return true
+end
+
+local graphite_nodes = {}
+
+local function apply_graphite(conf)
+    local graphite_plugin = require('metrics.plugins.graphite')
+
+    if not table_equals(graphite_nodes, conf) then
+        graphite_plugin.stop()
+
+        for _, graphite_node in ipairs(conf) do
+            graphite_plugin.init({
+                prefix = graphite_node.prefix,
+                host =  graphite_node.host,
+                port = tonumber(graphite_node.port),
+                send_interval = tonumber(graphite_node.send_interval),
+            })
+        end
+    end
+
+    graphite_nodes = conf
 end
 
 local function stop_graphite()
-    -- Will be implemented in the next PR.
+    require('metrics.plugins.graphite').stop()
+
+    graphite_nodes = {}
 end
 
 local function validate_http_endpoint(endpoint)
@@ -578,8 +624,8 @@ M.apply = function(conf)
 end
 
 M.stop = function()
-    for _, callbacks in pairs(export_targets) do
-        callbacks.stop()
+    for _, target in pairs(export_targets) do
+        target.stop()
     end
 end
 

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -8,6 +8,8 @@ local M = {}
 -- Requires manual update in case of release commit.
 M._VERSION = "0.3.2"
 
+local DEFAULT_GRAPHITE_SEND_INTERVAL = 2
+
 local function is_array(tbl)
     assert(type(tbl) == "table", "a table expected")
     for k, _ in pairs(tbl) do
@@ -107,6 +109,7 @@ local http_handlers = {
         return http_handler(...)
     end,
 }
+
 -- It is used as an error string with the predefined order.
 local http_supported_formats_str = "json, prometheus"
 
@@ -122,6 +125,76 @@ local function validate_endpoint_metrics(metrics)
     if metrics.enabled ~= nil and type(metrics.enabled) ~= 'boolean' then
         error("http endpoint metrics 'enabled' must be a boolean, got " .. type(metrics.enabled), 5)
     end
+end
+
+local function validate_graphite_port(port)
+    if port == nil then
+        error("graphite must have 'port'", 4)
+    end
+    if type(port) ~= "number" then
+        error("graphite 'port' must be a 'number', got " .. type(port), 4)
+    elseif port < 0 or port > 65535 then
+        error("graphite 'port' must be a valid port (0..65535), got " .. tostring(port), 4)
+    end
+end
+
+local function validate_graphite_send_interval(endpoint)
+    if endpoint.send_interval == nil then
+        endpoint.send_interval = DEFAULT_GRAPHITE_SEND_INTERVAL
+        return
+    elseif type(endpoint.send_interval) ~= "number" then
+        error("graphite 'send_interval' must be a 'number', got " .. type(endpoint.send_interval), 4)
+    elseif endpoint.send_interval <= 0 then
+        error("graphite 'send_interval' must be a positive number, got " .. tostring(endpoint.send_interval), 4)
+    end
+end
+
+local function validate_graphite_node(endpoint)
+    if type(endpoint) ~= "table" then
+        error("graphite node must be a table, got " .. type(endpoint), 4)
+    end
+    if next(endpoint) == nil then
+        error("graphite node must have configuration", 4)
+    end
+    if endpoint.prefix == nil then
+        error("graphite must have 'prefix'", 4)
+    end
+    if type(endpoint.prefix) ~= "string" then
+        error("graphite 'prefix' must be a 'string', got " .. type(endpoint.prefix), 4)
+    end
+    if endpoint.host == nil then
+        error("graphite must have 'host'", 4)
+    end
+    if type(endpoint.host) ~= "string" then
+        error("graphite 'host' must be a 'string', got " .. type(endpoint.host), 4)
+    end
+
+    validate_graphite_port(endpoint.port)
+
+    validate_graphite_send_interval(endpoint)
+end
+
+local function validate_graphite(conf)
+    if conf ~= nil and type(conf) ~= "table" then
+        error("graphite configuration must be a table, got " .. type(conf), 2)
+    end
+    conf = conf or {}
+
+    if not is_array(conf) then
+        error("graphite configuration must be an array, not a map", 2)
+    end
+
+    for _, graphite_node in ipairs(conf) do
+        validate_graphite_node(graphite_node)
+    end
+end
+
+local function apply_graphite()
+    -- Will be implemented in the next PR.
+end
+
+local function stop_graphite()
+    -- Will be implemented in the next PR.
 end
 
 local function validate_http_endpoint(endpoint)
@@ -470,6 +543,11 @@ local export_targets = {
         validate = validate_http,
         apply = apply_http,
         stop = stop_http,
+    },
+    ["graphite"] = {
+        validate = validate_graphite,
+        apply = apply_graphite,
+        stop = stop_graphite,
     },
 }
 

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -20,7 +20,7 @@ groups:
                 graphite:
                 - prefix: 'master'
                   host: '127.0.0.1'
-                  port: 2222
+                  port: 44444
                   send_interval: 1
                 - prefix: 'tarantool'
                   host: '127.0.0.1'

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -17,6 +17,14 @@ groups:
                 additional:
                   listen: '127.0.0.1:8086'
               roles.metrics-export:
+                graphite:
+                - prefix: 'master'
+                  host: '127.0.0.1'
+                  port: 2222
+                  send_interval: 1
+                - prefix: 'tarantool'
+                  host: '127.0.0.1'
+                  port: 2223
                 http:
                 - listen: 8081
                   endpoints:

--- a/test/helpers/graphite.lua
+++ b/test/helpers/graphite.lua
@@ -1,0 +1,51 @@
+local checks = require('checks')
+local socket = require('socket')
+
+local M = {}
+
+-- Default values
+local DEFAULT_PREFIX = 'tarantool'
+local DEFAULT_HOST = '127.0.0.1'
+local DEFAULT_PORT = 2003
+local DEFAULT_SEND_INTERVAL = 2
+
+M.count_graphite_frames = function (prefix, host, port, send_interval)
+    checks('?string', '?string', '?number', '?number')
+
+    prefix = prefix or DEFAULT_PREFIX
+    host = host or DEFAULT_HOST
+    port = port or DEFAULT_PORT
+    send_interval = send_interval or DEFAULT_SEND_INTERVAL
+
+    -- Create socket to recieve data from the role.
+    local sock = socket('AF_INET', 'SOCK_DGRAM', 'udp')
+    sock:bind(host, port)
+
+    sock:readable(send_interval * 2)
+
+    local frame_counter = 0
+
+    -- It’s not very clear how to keep the check simple and clear here. So we
+    -- just took lines in `graphite` format, and check that:
+    -- 1) metric name contains a valid prefix
+    -- 2) metric value is not missing
+    -- 3) metric timestamp is greater than 0.
+    while true do
+        local graphite_obs = sock:recvfrom()
+        if graphite_obs == nil then
+            break
+        end
+
+        local obs_table = graphite_obs:split(' ')
+
+        if string.find(obs_table[1], prefix) and (obs_table[2] ~= nil) and (tonumber(obs_table[3]) > 0) then
+            frame_counter = frame_counter + 1
+        end
+    end
+
+    sock:close()
+
+    return frame_counter
+end
+
+return M

--- a/test/helpers/mocks.lua
+++ b/test/helpers/mocks.lua
@@ -1,5 +1,5 @@
 -- M is a mocks module that uses for changing methods behaviour.
--- It could be useful in unit tests when we neeed to determine
+-- It could be useful in unit tests when we need to determine
 -- behaviour of methods that we don't need to test in it.
 local M = {}
 
@@ -42,7 +42,7 @@ M.apply = function(mocks)
     end
 end
 
--- M.delete returns original implementation from mocked method.
+-- M.clear returns original implementation from mocked method.
 M.clear = function()
     for _, mock in ipairs(M.mocks) do
        require(mock.module)[mock.method] = mock.original_implementation

--- a/test/integration/reload_config_test.lua
+++ b/test/integration/reload_config_test.lua
@@ -1,9 +1,10 @@
 local fio = require('fio')
-local yaml = require('yaml')
-local socket = require('socket')
+local graphite_helpers = require('test.helpers.graphite')
 local helpers = require('test.helpers')
-local server = require('test.helpers.server')
 local http_client = require('http.client'):new()
+local server = require('test.helpers.server')
+local socket = require('socket')
+local yaml = require('yaml')
 
 local t = require('luatest')
 local g = t.group()
@@ -117,8 +118,8 @@ g.test_reload_config_global_addr_conflict = function(cg)
 
     change_listen_target_in_config(cg, 8081, '0.0.0.0:8082')
     t.assert_error_msg_content_equals(
-      "Can't create tcp_server: Address already in use",
-      function() cg.server:eval("require('config'):reload()") end
+        "Can't create tcp_server: Address already in use",
+        function() cg.server:eval("require('config'):reload()") end
     )
 end
 
@@ -144,6 +145,7 @@ g.test_reload_config_routes_exists = function(cg)
     t.assert(response.body)
 
     change_http_addr_in_config(cg, 8088)
+
     _, err = cg.server:eval("require('config'):reload()")
     t.assert_not(err)
 
@@ -153,4 +155,49 @@ g.test_reload_config_routes_exists = function(cg)
     response = http_client:get('localhost:8088/metrics/prometheus')
     t.assert_equals(response.status, 200)
     t.assert(response.body)
+end
+
+local function change_graphite_port_in_config(cg, new_port)
+    if new_port == nil then
+        new_port = '2222'
+    end
+
+    local file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_RDONLY'})
+    t.assert(file ~= nil)
+
+    local cfg = file:read()
+    file:close()
+
+    cfg = yaml.decode(cfg)
+
+    cfg.groups['group-001'].replicasets['replicaset-001'].instances.master.
+        roles_cfg['roles.metrics-export'].graphite[2].port = new_port
+
+    file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}, tonumber('644', 8))
+    file:write(yaml.encode(cfg))
+    file:close()
+end
+
+
+g.test_reload_config_graphite = function(cg)
+    cg.server = server:new({
+        config_file = fio.pathjoin(cg.workdir, 'config.yaml'),
+        chdir = cg.workdir,
+        alias = 'master',
+        workdir = cg.workdir,
+    })
+
+    cg.server:start({wait_until_ready = true})
+
+    t.assert_ge(graphite_helpers.count_graphite_frames("master", "127.0.0.1", 44444, 1), 1)
+    t.assert_ge(graphite_helpers.count_graphite_frames("tarantool", "127.0.0.1", 2223, 2), 1)
+
+    change_graphite_port_in_config(cg, 3333)
+
+    local _, err = cg.server:eval("require('config'):reload()")
+    t.assert_not(err)
+
+    t.assert_ge(graphite_helpers.count_graphite_frames("master", "127.0.0.1", 44444, 1), 1)
+    t.assert_ge(graphite_helpers.count_graphite_frames("tarantool", "127.0.0.1", 3333, 2), 1)
+    t.assert_equals(graphite_helpers.count_graphite_frames("tarantool", "127.0.0.1", 2223, 2), 0)
 end

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -1,4 +1,5 @@
 local fio = require('fio')
+local graphite_helpers = require('test.helpers.graphite')
 local json = require('json')
 local helpers = require('test.helpers')
 local http_client = require('http.client'):new()
@@ -19,7 +20,7 @@ g.before_each(function(cg)
     fio.copytree("roles", fio.pathjoin(cg.workdir, "roles"))
     fio.copytree(fio.pathjoin("test", "ssl_data"), fio.pathjoin(cg.workdir, "ssl_data"))
 
-    cg.router = server:new({
+    cg.master = server:new({
         config_file = fio.abspath(fio.pathjoin('test', 'entrypoint', 'config.yaml')),
         chdir = cg.workdir,
         alias = 'master',
@@ -29,11 +30,11 @@ g.before_each(function(cg)
     -- It takes around 1s to start an instance, which considering small amount
     -- of integration tests is not a problem. But at the same time, we have a
     -- clean work environment.
-    cg.router:start{wait_until_ready = true}
+    cg.master:start{wait_until_ready = true}
 end)
 
 g.after_each(function(cg)
-    cg.router:stop()
+    cg.master:stop()
     fio.rmtree(cg.workdir)
 end)
 
@@ -136,4 +137,9 @@ g.test_endpoint_with_tls = function(cg)
     assert_json("https://localhost:8087/metrics/json/", client_tls_opts)
     assert_not_observed("https://localhost:8087", "/metrics/prometheus", client_tls_opts)
     assert_observed("https://localhost:8087", "/metrics/observed/prometheus/1", client_tls_opts)
+end
+
+g.test_graphite_servers = function()
+    t.assert_ge(graphite_helpers.count_graphite_frames("master", "127.0.0.1", 44444, 1), 1)
+    t.assert_ge(graphite_helpers.count_graphite_frames("tarantool", "127.0.0.1", 2223, 2), 1)
 end

--- a/test/unit/graphite_test.lua
+++ b/test/unit/graphite_test.lua
@@ -1,0 +1,351 @@
+local graphite_helpers = require('test.helpers.graphite')
+local metrics = require('metrics')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.role = require('roles.metrics-export')
+end)
+
+g.before_each(function(cg)
+    -- Add custom metric.
+    cg.counter = metrics.counter('some_counter')
+    cg.counter:inc(1, {label = 'ANY'})
+end)
+
+g.after_each(function(cg)
+    cg.role.stop()
+
+    -- Unregister custom metric.
+    metrics.registry:unregister(cg.counter)
+end)
+
+local test_graphite_server_cases = {
+    ["default"] = {
+        cfg = {
+            graphite = {},
+        },
+    },
+    ["custom"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = "master",
+                    host = "127.0.0.1",
+                    port = 3333,
+                    send_interval = 1,
+                },
+            },
+        },
+    },
+    ["array"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = "master",
+                    host = "127.0.0.1",
+                    port = 3333,
+                    send_interval = 1,
+                },
+                {
+                    prefix = "tarantool",
+                    host = "127.0.0.1",
+                    port = 4444,
+                    send_interval = 1,
+                },
+            },
+        },
+    },
+}
+
+for name, case in pairs(test_graphite_server_cases) do
+    g['test_graphite_server_' .. name] = function(cg)
+        cg.role.apply(case.cfg)
+
+        for i in pairs(case.cfg.graphite) do
+            t.assert_ge(graphite_helpers.count_graphite_frames(
+                case.cfg.graphite[i].prefix, case.cfg.graphite[i].host,
+                case.cfg.graphite[i].port, case.cfg.graphite[i].send_interval),
+                1)
+        end
+    end
+end
+
+local test_graphite_invalid_cases = {
+    ["cfg_number"] = {
+        cfg = {
+            graphite = 123,
+        },
+        err = "graphite configuration must be a table, got number"
+    },
+    ["cfg_map"] = {
+        cfg = {
+            graphite = {
+                [1] = "first",
+                ["space key"] = "space value"
+            },
+        },
+        err = "graphite configuration must be an array, not a map"
+    },
+    ["invalid_prefix"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = 123456,
+                    host = "127.0.0.1",
+                    port = 3333,
+                    send_interval = 1,
+                },
+            },
+        },
+        err = "graphite 'prefix' must be a 'string', got number"
+    },
+    ["invalid_host"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = "master",
+                    host = 123,
+                    port = 3333,
+                    send_interval = 1,
+                },
+            },
+        },
+        err = "graphite 'host' must be a 'string', got number"
+    },
+    ["invalid_port"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = "master",
+                    host = "127.0.0.1",
+                    port = "3333",
+                    send_interval = 1,
+                },
+            },
+        },
+        err = "graphite 'port' must be a 'number', got string"
+    },
+    ["invalid_send_interval"] = {
+        cfg = {
+            graphite = {
+                {
+                    prefix = "master",
+                    host = "127.0.0.1",
+                    port = 3333,
+                    send_interval = "1",
+                },
+            },
+        },
+        err = "graphite 'send_interval' must be a 'number', got string"
+    },
+}
+
+for name, case in pairs(test_graphite_invalid_cases) do
+    g['test_graphite_invalid_' .. name] = function(cg)
+        local ok, err = pcall(cg.role.apply, case.cfg)
+
+        t.assert_str_contains(err, case.err)
+        t.assert_not(ok)
+    end
+end
+
+local test_graphite_reapply_cases = {
+    ["prefix_change"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "tarantool",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+    ["add_new_server"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                        {
+                            prefix = "tarantool",
+                            host = "127.0.0.1",
+                            port = 4444,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+    ["remove_server"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                        {
+                            prefix = "tarantool",
+                            host = "127.0.0.1",
+                            port = 4444,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                    },
+                },
+                stopped = {
+                    graphite = {
+                        {
+                            prefix = "tarantool",
+                            host = "127.0.0.1",
+                            port = 4444,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+for name, case in pairs(test_graphite_reapply_cases) do
+    g["test_graphite_reapply_" .. name] = function (cg)
+        for _, apply_iter in ipairs(case.apply_cases) do
+            cg.role.apply(apply_iter.cfg)
+
+            for i in pairs(apply_iter.cfg.graphite) do
+                t.assert_equals(graphite_helpers.count_graphite_frames(
+                    apply_iter.cfg.graphite[i].prefix, apply_iter.cfg.graphite[i].host,
+                    apply_iter.cfg.graphite[i].port, apply_iter.cfg.graphite[i].send_interval),
+                    1)
+            end
+
+            if apply_iter.stopped ~= nil then
+                for i in pairs(apply_iter.stopped.graphite) do
+                    t.assert_equals(graphite_helpers.count_graphite_frames(
+                        apply_iter.stopped.graphite[i].prefix, apply_iter.stopped.graphite[i].host,
+                        apply_iter.stopped.graphite[i].port, apply_iter.stopped.graphite[i].send_interval),
+                        0)
+                end
+            end
+        end
+    end
+end
+
+
+local test_graphite_stop_cases = {
+    ["one_server"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+    ["two_servers"] = {
+        apply_cases = {
+            {
+                cfg = {
+                    graphite = {
+                        {
+                            prefix = "master",
+                            host = "127.0.0.1",
+                            port = 3333,
+                            send_interval = 1,
+                        },
+                        {
+                            prefix = "tarantool",
+                            host = "127.0.0.1",
+                            port = 4444,
+                            send_interval = 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+for name, case in pairs(test_graphite_stop_cases) do
+    g["test_graphite_stop_" .. name] = function (cg)
+        for _, apply_iter in ipairs(case.apply_cases) do
+            cg.role.apply(apply_iter.cfg)
+
+            for i in pairs(apply_iter.cfg.graphite) do
+                t.assert_ge(graphite_helpers.count_graphite_frames(
+                    apply_iter.cfg.graphite[i].prefix, apply_iter.cfg.graphite[i].host,
+                    apply_iter.cfg.graphite[i].port, apply_iter.cfg.graphite[i].send_interval),
+                    1)
+            end
+
+            cg.role.stop()
+
+            for i in pairs(apply_iter.cfg.graphite) do
+                t.assert_equals(graphite_helpers.count_graphite_frames(
+                    apply_iter.cfg.graphite[i].prefix, apply_iter.cfg.graphite[i].host,
+                    apply_iter.cfg.graphite[i].port, apply_iter.cfg.graphite[i].send_interval),
+                    0)
+            end
+        end
+    end
+end

--- a/test/unit/validate_test.lua
+++ b/test/unit/validate_test.lua
@@ -629,6 +629,144 @@ local error_cases = {
         },
         err = "tls options are availabe only with 'listen' parameter",
     },
+    ["graphite_not_a_table"] = {
+        cfg = {
+            graphite = 123,
+        },
+        err = "graphite configuration must be a table, got number"
+    },
+    ["graphite_node_not_a_table"] = {
+        cfg = {
+            graphite = {
+                123,456
+            },
+        },
+        err = "graphite node must be a table, got number"
+    },
+    ["graphite_no_params"] = {
+        cfg = {
+            graphite = {{}},
+        },
+        err = "graphite node must have configuration"
+    },
+    ["graphite_no_prefix"] = {
+        cfg = {
+            graphite = {{
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'prefix'"
+    },
+    ["graphite_prefix_invalid"] = {
+        cfg = {
+            graphite = {{
+                prefix = 123,
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'prefix' must be a 'string', got number"
+    },
+    ["graphite_no_host"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'host'"
+    },
+    ["graphite_host_invalid"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = 123,
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'host' must be a 'string', got number"
+    },
+    ["graphite_no_port"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                send_interval = 1,
+            },},
+        },
+        err = "graphite must have 'port'"
+    },
+    ["graphite_port_string"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = '2222',
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a 'number', got string"
+    },
+    ["graphite_port_negative"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = -2222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a valid port (0..65535), got "
+    },
+    ["graphite_port_overflow"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 111222,
+                send_interval = 1,
+            },},
+        },
+        err = "graphite 'port' must be a valid port (0..65535), got "
+    },
+    ["graphite_send_interval_string"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = '1',
+            },},
+        },
+        err = "graphite 'send_interval' must be a 'number', got string"
+    },
+    ["graphite_send_interval_negative"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = -1,
+            },},
+        },
+        err = "graphite 'send_interval' must be a positive number"
+    },
+    ["graphite_send_interval_zero"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 0,
+            },},
+        },
+        err = "graphite 'send_interval' must be a positive number"
+    },
 }
 
 for name, case in pairs(error_cases) do
@@ -892,6 +1030,41 @@ local ok_cases = {
                     ssl_password_file = "ssl_password_file",
                 },
             },
+        },
+    },
+    ["graphite_full"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },},
+        },
+    },
+    ["graphite_no_send_interval"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+            },},
+        },
+    },
+    ["graphite_two_servers"] = {
+        cfg = {
+            graphite = {{
+                prefix = "master",
+                host = "127.0.0.1",
+                port = 2222,
+                send_interval = 1,
+            },
+            {
+                prefix = "tarantool",
+                host = "127.0.0.1",
+                port = 2223,
+                send_interval = 3,
+            },},
         },
     },
 }

--- a/test/unit/validate_test.lua
+++ b/test/unit/validate_test.lua
@@ -629,20 +629,6 @@ local error_cases = {
         },
         err = "tls options are availabe only with 'listen' parameter",
     },
-    ["graphite_not_a_table"] = {
-        cfg = {
-            graphite = 123,
-        },
-        err = "graphite configuration must be a table, got number"
-    },
-    ["graphite_node_not_a_table"] = {
-        cfg = {
-            graphite = {
-                123,456
-            },
-        },
-        err = "graphite node must be a table, got number"
-    },
     ["graphite_no_params"] = {
         cfg = {
             graphite = {{}},
@@ -717,11 +703,11 @@ local error_cases = {
             graphite = {{
                 prefix = "master",
                 host = "127.0.0.1",
-                port = -2222,
+                port = 0,
                 send_interval = 1,
             },},
         },
-        err = "graphite 'port' must be a valid port (0..65535), got "
+        err = "graphite 'port' must be a valid port (1..65535), got "
     },
     ["graphite_port_overflow"] = {
         cfg = {
@@ -732,7 +718,7 @@ local error_cases = {
                 send_interval = 1,
             },},
         },
-        err = "graphite 'port' must be a valid port (0..65535), got "
+        err = "graphite 'port' must be a valid port (1..65535), got "
     },
     ["graphite_send_interval_string"] = {
         cfg = {
@@ -1064,7 +1050,8 @@ local ok_cases = {
                 host = "127.0.0.1",
                 port = 2223,
                 send_interval = 3,
-            },},
+            },
+        },
         },
     },
 }


### PR DESCRIPTION
This patch adds support for exporting metrics in the `graphite` format.

Closes #TNTP-6584