### PR TITLE
Release 0.4.1

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Tarantool CE
       uses: tarantool/setup-tarantool@v4
       with:
-        tarantool-version: '3.6.0'
+        tarantool-version: '3.7.0'
 
     - name: Setup tt
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Clone the module
         uses: actions/checkout@v4
 
-      - name: Install tarantool 3.6
+      - name: Install tarantool 3.7
         uses: tarantool/setup-tarantool@v4
         with:
-          tarantool-version: '3.6'
+          tarantool-version: '3.7'
 
       - name: Setup tt
         run: |
@@ -94,7 +94,7 @@ jobs:
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
       - uses: tarantool/setup-tarantool@v3
         with:
-          tarantool-version: '3.1'
+          tarantool-version: '3.7'
       - run: tt rocks install metrics-export-role-${{ env.TAG }}-1.rockspec
       - run: tt rocks pack metrics-export-role ${{ env.TAG }}
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,7 @@ jobs:
         include:
           # We test role for min supported tarantool version and the latest one.
           - tarantool: '3.0.2'
-          - tarantool: '3.6.2'
+          - tarantool: '3.7.0'
     env:
       TNT_DEBUG_PATH: /home/runner/tnt-debug
 
@@ -78,7 +78,7 @@ jobs:
       - name: Install Tarantool
         uses: ./.github/actions/install-tarantool
         with: 
-          tarantool: '3.6'
+          tarantool: '3.7'
 
       - name: Install requirements
         run: make deps depname=coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.1 - 2026-05-07
+
+Fixed a strict requirement for Tarantool versions in which the `metrics` module
+does not yet provide full support for Graphite.
 
 ### Fixed
 
 - Hard dependency on metrics 1.7.0 version even if Graphite is not used.
 
-## 0.4.0 - 2025-03-27
+## 0.4.0 - 2026-03-27
 
 This release adds support for `Graphite`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Hard dependency on metrics 1.7.0 version even if Graphite is not used.
+
 ## 0.4.0 - 2025-03-27
 
 This release adds support for `Graphite`.

--- a/metrics-export-role-scm-1.rockspec
+++ b/metrics-export-role-scm-1.rockspec
@@ -17,7 +17,6 @@ dependencies = {
     "lua >= 5.1",
     "tarantool >= 3.0.2",
     "http >= 1.7.0",
-    "metrics >= 1.7.0",
 }
 
 build = {

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -6,7 +6,7 @@ local M = {}
 
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
-M._VERSION = "0.4.0"
+M._VERSION = "0.4.1"
 
 local DEFAULT_GRAPHITE_SEND_INTERVAL = 2
 

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -175,6 +175,12 @@ local function validate_graphite_node(endpoint)
 end
 
 local function validate_graphite(conf)
+    local ok = pcall(require('metrics.plugins.graphite').stop)
+    if not ok then
+        error('ensure you have metrics 1.7.0+ (provided with Tarantool 3.7.0+ or can be ' ..
+            'installed as an external dependency)', 2)
+    end
+
     if conf ~= nil and type(conf) ~= "table" then
         error("graphite configuration must be a table, got " .. type(conf), 2)
     end
@@ -238,9 +244,12 @@ local function apply_graphite(conf)
 end
 
 local function stop_graphite()
-    require('metrics.plugins.graphite').stop()
+    local is_empty = next(graphite_nodes) == nil
 
-    graphite_nodes = {}
+    if not is_empty then
+        require('metrics.plugins.graphite').stop()
+        graphite_nodes = {}
+    end
 end
 
 local function validate_http_endpoint(endpoint)

--- a/test/entrypoint/config.yaml
+++ b/test/entrypoint/config.yaml
@@ -17,14 +17,6 @@ groups:
                 additional:
                   listen: '127.0.0.1:8086'
               roles.metrics-export:
-                graphite:
-                - prefix: 'master'
-                  host: '127.0.0.1'
-                  port: 44444
-                  send_interval: 1
-                - prefix: 'tarantool'
-                  host: '127.0.0.1'
-                  port: 2223
                 http:
                 - listen: 8081
                   endpoints:

--- a/test/entrypoint/graphite_config.yaml
+++ b/test/entrypoint/graphite_config.yaml
@@ -1,0 +1,27 @@
+credentials:
+  users:
+    guest:
+      roles: [super]
+
+groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        instances:
+          master:
+            roles: [roles.httpd, roles.metrics-export]
+            roles_cfg:
+              roles.metrics-export:
+                graphite:
+                - prefix: 'master'
+                  host: '127.0.0.1'
+                  port: 44444
+                  send_interval: 1
+                - prefix: 'tarantool'
+                  host: '127.0.0.1'
+                  port: 2223
+            iproto:
+              listen:
+                - uri: '127.0.0.1:3313'
+            database:
+              mode: rw

--- a/test/helpers/init.lua
+++ b/test/helpers/init.lua
@@ -1,21 +1,20 @@
 local t = require("luatest")
+local luatest_utils = require('luatest.utils')
 
 local helpers = {}
 
-local function tarantool_version()
-    local major_minor_patch = _G._TARANTOOL:split('-', 1)[1]
-    local major_minor_patch_parts = major_minor_patch:split('.', 2)
-
-    local major = tonumber(major_minor_patch_parts[1])
-    local minor = tonumber(major_minor_patch_parts[2])
-    local patch = tonumber(major_minor_patch_parts[3])
-
-    return major, minor, patch
+local function tarantool_role_is_supported()
+    local tarantool_version = luatest_utils.get_tarantool_version()
+    return luatest_utils.version_ge(tarantool_version, luatest_utils.version(3, 0, 0))
 end
 
-local function tarantool_role_is_supported()
-    local major, _, _ = tarantool_version()
-    return major >= 3
+function helpers.is_tarantool3_7_0()
+    local tarantool_version = luatest_utils.get_tarantool_version()
+    return luatest_utils.version_ge(tarantool_version, luatest_utils.version(3, 7, 0))
+end
+
+function helpers.skip_if_graphite_unsupported()
+    t.skip_if(not helpers.is_tarantool3_7_0(), 'Only Tarantool 3.7.0 or newer supports Graphite')
 end
 
 function helpers.skip_if_unsupported()

--- a/test/integration/reload_config_test.lua
+++ b/test/integration/reload_config_test.lua
@@ -162,7 +162,7 @@ local function change_graphite_port_in_config(cg, new_port)
         new_port = '2222'
     end
 
-    local file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_RDONLY'})
+    local file = fio.open(fio.pathjoin(cg.workdir, 'graphite_config.yaml'), {'O_RDONLY'})
     t.assert(file ~= nil)
 
     local cfg = file:read()
@@ -173,15 +173,23 @@ local function change_graphite_port_in_config(cg, new_port)
     cfg.groups['group-001'].replicasets['replicaset-001'].instances.master.
         roles_cfg['roles.metrics-export'].graphite[2].port = new_port
 
-    file = fio.open(fio.pathjoin(cg.workdir, 'config.yaml'), {'O_CREAT', 'O_WRONLY', 'O_TRUNC'}, tonumber('644', 8))
+    file = fio.open(
+        fio.pathjoin(cg.workdir, 'graphite_config.yaml'),
+        {'O_CREAT', 'O_WRONLY', 'O_TRUNC'},
+        tonumber('644', 8)
+    )
     file:write(yaml.encode(cfg))
     file:close()
 end
 
+g.before_test('test_reload_config_graphite', function(cg)
+    helpers.skip_if_graphite_unsupported()
+    fio.copyfile(fio.pathjoin('test', 'entrypoint', 'graphite_config.yaml'), cg.workdir)
+end)
 
 g.test_reload_config_graphite = function(cg)
     cg.server = server:new({
-        config_file = fio.pathjoin(cg.workdir, 'config.yaml'),
+        config_file = fio.pathjoin(cg.workdir, 'graphite_config.yaml'),
         chdir = cg.workdir,
         alias = 'master',
         workdir = cg.workdir,

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -139,6 +139,21 @@ g.test_endpoint_with_tls = function(cg)
     assert_observed("https://localhost:8087", "/metrics/observed/prometheus/1", client_tls_opts)
 end
 
+g.before_test('test_graphite_servers', function(cg)
+    helpers.skip_if_graphite_unsupported()
+
+    if cg.master then
+        cg.master:stop()
+    end
+    cg.master = server:new({
+        config_file = fio.abspath(fio.pathjoin('test', 'entrypoint', 'graphite_config.yaml')),
+        chdir = cg.workdir,
+        alias = 'master',
+        workdir = cg.workdir,
+    })
+    cg.master:start{wait_until_ready = true}
+end)
+
 g.test_graphite_servers = function()
     t.assert_ge(graphite_helpers.count_graphite_frames("master", "127.0.0.1", 44444, 1), 1)
     t.assert_ge(graphite_helpers.count_graphite_frames("tarantool", "127.0.0.1", 2223, 2), 1)

--- a/test/unit/graphite_test.lua
+++ b/test/unit/graphite_test.lua
@@ -1,10 +1,13 @@
 local graphite_helpers = require('test.helpers.graphite')
+local helpers = require('test.helpers')
+
 local metrics = require('metrics')
 
 local t = require('luatest')
 local g = t.group()
 
 g.before_all(function(cg)
+    helpers.skip_if_graphite_unsupported()
     cg.role = require('roles.metrics-export')
 end)
 

--- a/test/unit/validate_test.lua
+++ b/test/unit/validate_test.lua
@@ -2,6 +2,7 @@ local t = require('luatest')
 local g = t.group()
 
 local mocks = require('test.helpers.mocks')
+local helpers = require('test.helpers')
 
 local httpd_config = {
     default = {
@@ -190,6 +191,17 @@ local error_cases = {
             },
         },
         err = "failed to parse http 'listen' param: URI query component is not supported",
+    },
+    ["http_node_listen_uri_invalid"] = {
+        cfg = {
+            http = {
+                {
+                    listen = "not a valid uri",
+                    endpoints = {},
+                },
+            },
+        },
+        err = "failed to parse http 'listen' param: failed to parse URI",
     },
     ["http_node_endpoints_not_table"] = {
         cfg = {
@@ -635,6 +647,12 @@ local error_cases = {
         },
         err = "graphite node must have configuration"
     },
+    ["graphite_not_table"] = {
+        cfg = {
+            graphite = {5},
+        },
+        err = "graphite node must be a table, got number"
+    },
     ["graphite_no_prefix"] = {
         cfg = {
             graphite = {{
@@ -761,9 +779,15 @@ for name, case in pairs(error_cases) do
             mocks.apply(case.mocks)
         end
 
-        t.assert_error_msg_contains(case.err, function()
-            gc.role.validate(case.cfg)
-        end)
+        if type(case.cfg) == 'table' and case.cfg.graphite and not helpers.is_tarantool3_7_0() then
+            t.assert_error_msg_contains(
+                'ensure you have metrics 1.7.0+ (provided with Tarantool 3.7.0+ or can be ' ..
+                'installed as an external dependency)',
+                function() gc.role.validate(case.cfg) end
+            )
+        else
+            t.assert_error_msg_contains(case.err, function() gc.role.validate(case.cfg) end)
+        end
 
         if case.mocks ~= nil then
             mocks.clear()
@@ -773,6 +797,8 @@ end
 
 for name, case in pairs(error_cases) do
     g["test_apply_validate_error_" .. name] = function(gc)
+        helpers.skip_if_graphite_unsupported()
+
         if case.mocks ~= nil then
             mocks.apply(case.mocks)
         end
@@ -1058,6 +1084,10 @@ local ok_cases = {
 
 for name, case in pairs(ok_cases) do
     g["test_validate_ok_" .. name] = function(gc)
+        if (case.cfg or {}).graphite ~= nil then
+            helpers.skip_if_graphite_unsupported()
+        end
+
         if case.mocks ~= nil then
             mocks.apply(case.mocks)
         end


### PR DESCRIPTION
Fixed a strict requirement for Tarantool versions in which the `metrics` module does not yet provide full support for Graphite.

### Fixed

- Hard dependency on metrics 1.7.0 version even if Graphite is not used.
