### PR TITLE
roles: stop removed export targets on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Export targets not being stopped after removal from the role configuration (#47).
+
 ## 0.4.1 - 2026-05-07
 
 Fixed a strict requirement for Tarantool versions in which the `metrics` module

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -627,7 +627,13 @@ M.apply = function(conf)
     -- a meaningful error if something goes wrong.
     M.validate(conf)
 
-    for export_target, opts in pairs(conf or {}) do
+    conf = conf or {}
+    for export_target, target in pairs(export_targets) do
+        if conf[export_target] == nil then
+            target.stop()
+        end
+    end
+    for export_target, opts in pairs(conf) do
         export_targets[export_target].apply(opts)
     end
 end

--- a/test/integration/reload_config_test.lua
+++ b/test/integration/reload_config_test.lua
@@ -157,6 +157,38 @@ g.test_reload_config_routes_exists = function(cg)
     t.assert(response.body)
 end
 
+g.test_reload_config_remove_http_target = function(cg)
+    cg.server = server:new({
+        config_file = fio.pathjoin(cg.workdir, 'config.yaml'),
+        chdir = cg.workdir,
+        alias = 'master',
+        workdir = cg.workdir,
+    })
+    cg.server:start({wait_until_ready = true})
+    t.assert(is_tcp_connect('127.0.0.1', 8082))
+
+    local config_path = fio.pathjoin(cg.workdir, 'config.yaml')
+    local file = fio.open(config_path, {'O_RDONLY'})
+    t.assert(file ~= nil)
+    local cfg = yaml.decode(file:read())
+    file:close()
+
+    local role_cfg = cfg.groups['group-001'].replicasets['replicaset-001'].
+        instances.master.roles_cfg['roles.metrics-export']
+    role_cfg.http = nil
+
+    file = fio.open(config_path, {
+        'O_CREAT', 'O_WRONLY', 'O_TRUNC',
+    }, tonumber('644', 8))
+    t.assert(file ~= nil)
+    file:write(yaml.encode(cfg))
+    file:close()
+
+    local _, err = cg.server:eval("require('config'):reload()")
+    t.assert_not(err)
+    t.assert_not(is_tcp_connect('127.0.0.1', 8082))
+end
+
 local function change_graphite_port_in_config(cg, new_port)
     if new_port == nil then
         new_port = '2222'


### PR DESCRIPTION
Stop export targets missing from the new role configuration before applying the remaining targets.

Closes #47