### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.2 - 2026-08-07
+
+The release fixes several bugs which affect export targets on config reload.
 
 ### Fixed
 

--- a/roles/metrics-export.lua
+++ b/roles/metrics-export.lua
@@ -6,7 +6,7 @@ local M = {}
 
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
-M._VERSION = "0.4.1"
+M._VERSION = "0.4.2"
 
 local DEFAULT_GRAPHITE_SEND_INTERVAL = 2
 


### PR DESCRIPTION
The release fixes several bugs which affect export targets on config reload.

### Fixed

- Export targets not being stopped after removal from the role configuration (#47).
- Graphite exporters stop after a configuration reload that keeps the
  `graphite` section unchanged.
- Requirement of metrics 1.7.0+ for an empty `graphite` section.